### PR TITLE
Fix invalid local volume name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ wrk:
   build: environments/wrk
 
   volumes:
-   - environments/wrk/scripts:/scripts
+   - ./environments/wrk/scripts:/scripts
 
   links:
    - application


### PR DESCRIPTION
Hey,

Thanks for putting the work into this. Meant I could quickly get a crasp of wrk's lua capabilities and trial some scripts.

Only problem I had during setup was the following error from docker-compose (version 1.7.0 and 1.9.0):
```
ERROR: Cannot create container for service wrk: create environments/wrk/scripts: "environments/wrk/scripts" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
```

adding `./` in front of the local volume path sorted it.

Thanks!
Alex